### PR TITLE
Lock down NPM dependencies

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,0 +1,268 @@
+{
+  "name": "ebay-api",
+  "version": "1.12.0",
+  "dependencies": {
+    "async": {
+      "version": "1.5.0"
+    },
+    "debug": {
+      "version": "2.2.0",
+      "dependencies": {
+        "ms": {
+          "version": "0.7.1"
+        }
+      }
+    },
+    "lodash": {
+      "version": "3.10.1"
+    },
+    "request": {
+      "version": "2.67.0",
+      "dependencies": {
+        "bl": {
+          "version": "1.0.0",
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.0.4",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.2"
+                },
+                "inherits": {
+                  "version": "2.0.1"
+                },
+                "isarray": {
+                  "version": "0.0.1"
+                },
+                "process-nextick-args": {
+                  "version": "1.0.6"
+                },
+                "string_decoder": {
+                  "version": "0.10.31"
+                },
+                "util-deprecate": {
+                  "version": "1.0.2"
+                }
+              }
+            }
+          }
+        },
+        "caseless": {
+          "version": "0.11.0"
+        },
+        "extend": {
+          "version": "3.0.0"
+        },
+        "forever-agent": {
+          "version": "0.6.1"
+        },
+        "form-data": {
+          "version": "1.0.0-rc3"
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1"
+        },
+        "mime-types": {
+          "version": "2.1.8",
+          "dependencies": {
+            "mime-db": {
+              "version": "1.20.0"
+            }
+          }
+        },
+        "node-uuid": {
+          "version": "1.4.7"
+        },
+        "qs": {
+          "version": "5.2.0"
+        },
+        "tunnel-agent": {
+          "version": "0.4.2"
+        },
+        "tough-cookie": {
+          "version": "2.2.1"
+        },
+        "http-signature": {
+          "version": "1.1.0",
+          "dependencies": {
+            "assert-plus": {
+              "version": "0.1.5"
+            },
+            "jsprim": {
+              "version": "1.2.2",
+              "dependencies": {
+                "extsprintf": {
+                  "version": "1.0.2"
+                },
+                "json-schema": {
+                  "version": "0.2.2"
+                },
+                "verror": {
+                  "version": "1.3.6"
+                }
+              }
+            },
+            "sshpk": {
+              "version": "1.7.1",
+              "dependencies": {
+                "asn1": {
+                  "version": "0.2.3"
+                },
+                "assert-plus": {
+                  "version": "0.2.0"
+                },
+                "dashdash": {
+                  "version": "1.10.1",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "0.1.5"
+                    }
+                  }
+                },
+                "jsbn": {
+                  "version": "0.1.0"
+                },
+                "tweetnacl": {
+                  "version": "0.13.2"
+                },
+                "jodid25519": {
+                  "version": "1.0.2"
+                },
+                "ecc-jsbn": {
+                  "version": "0.1.1"
+                }
+              }
+            }
+          }
+        },
+        "oauth-sign": {
+          "version": "0.8.0"
+        },
+        "hawk": {
+          "version": "3.1.2",
+          "dependencies": {
+            "hoek": {
+              "version": "2.16.3"
+            },
+            "boom": {
+              "version": "2.10.1"
+            },
+            "cryptiles": {
+              "version": "2.0.5"
+            },
+            "sntp": {
+              "version": "1.0.9"
+            }
+          }
+        },
+        "aws-sign2": {
+          "version": "0.6.0"
+        },
+        "stringstream": {
+          "version": "0.0.5"
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "dependencies": {
+            "delayed-stream": {
+              "version": "1.0.0"
+            }
+          }
+        },
+        "isstream": {
+          "version": "0.1.2"
+        },
+        "is-typedarray": {
+          "version": "1.0.0"
+        },
+        "har-validator": {
+          "version": "2.0.3",
+          "dependencies": {
+            "chalk": {
+              "version": "1.1.1",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.1.0"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.3"
+                },
+                "has-ansi": {
+                  "version": "2.0.0",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.0.0"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "3.0.0",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.0.0"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "2.0.0"
+                }
+              }
+            },
+            "commander": {
+              "version": "2.9.0",
+              "dependencies": {
+                "graceful-readlink": {
+                  "version": "1.0.1"
+                }
+              }
+            },
+            "is-my-json-valid": {
+              "version": "2.12.3",
+              "dependencies": {
+                "generate-function": {
+                  "version": "2.0.0"
+                },
+                "generate-object-property": {
+                  "version": "1.2.0",
+                  "dependencies": {
+                    "is-property": {
+                      "version": "1.0.2"
+                    }
+                  }
+                },
+                "jsonpointer": {
+                  "version": "2.0.0"
+                },
+                "xtend": {
+                  "version": "4.0.1"
+                }
+              }
+            },
+            "pinkie-promise": {
+              "version": "2.0.0",
+              "dependencies": {
+                "pinkie": {
+                  "version": "2.0.1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "xml": {
+      "version": "1.0.0"
+    },
+    "xml2js": {
+      "version": "0.4.15",
+      "dependencies": {
+        "sax": {
+          "version": "1.1.4"
+        },
+        "xmlbuilder": {
+          "version": "4.1.0"
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,12 +9,12 @@
   },
   "main": "index.js",
   "dependencies": {
-    "async": "^1.4.2",
-    "debug": "^2.2.0",
-    "lodash": "^3.10.1",
-    "request": "^2.65.0",
-    "xml": "^1.0.0",
-    "xml2js": "^0.4.12"
+    "async": "1.5.0",
+    "debug": "2.2.0",
+    "lodash": "3.10.1",
+    "request": "2.67.0",
+    "xml": "1.0.0",
+    "xml2js": "0.4.15"
   },
   "devDependencies": {
     "chai": "^3.3.0",


### PR DESCRIPTION
Add a npm-shrinkwrap.json file using the same versions of every dependency
that we use in the Shyp API's version of `ebay-api`. More or less copied the
relevant parts of the API's npm-shrinkwrap.json directly to here.