### PR TITLE
Force negotiation using TLSv1.0

### DIFF
--- a/lib/xml-request.js
+++ b/lib/xml-request.js
@@ -105,6 +105,31 @@ exports.xmlRequest = function(options, callback) {
   options.reqOptions = _.extend({
     url: buildRequestUrl(options),
     body: buildXmlInput(options),
+    // As of 3/22/2016, the eBay API has several servers that can only
+    // negotiate TLS v1.0 sessions, and several servers that can negotiate TLS
+    // v1.0, v1.1 and v1.2. Node/OpenSSL get confused by this, and occasionally
+    // attempt to parse a v1.2 response using TLS v1.0 and vice versa. The
+    // error you get back from the request looks something like this:
+    //
+    // { [Error: write EPROTO 140113357338496:error:1408F10B:SSL
+    //    routines:SSL3_GET_RECORD:wrong version number:../deps/openssl/openssl/ssl/s3_pkt.c:362:
+    //    ] code: 'EPROTO',
+    //    errno: 'EPROTO',
+    //    syscall: 'write' }
+    //
+    // As far as I can tell, this isn't patched yet, in Node or OpenSSL. But
+    // setting the following options forces all connections to be negotiated
+    // with TLS v1.0, effectively fixing the issue.
+    //
+    // More reading:
+    //
+    // https://github.com/aws/aws-sdk-js/issues/862
+    // https://github.com/nodejs/node/issues/3692
+    // https://www.ssllabs.com/ssltest/analyze.html?d=api.ebay.com
+    agentOptions: {
+      ciphers: 'ALL',
+      secureProtocol: 'TLSv1_method',
+    },
   }, options.reqOptions);
 
   debug('XML request options', options.reqOptions);

--- a/test/xml-request.test.js
+++ b/test/xml-request.test.js
@@ -2,7 +2,7 @@ require('./helpers');
 
 var
   request = require('request'),
-  ebay = require('../index')
+  ebay = require('../index'),
   xmlRequest = ebay.xmlRequest;
 
 describe('XML requests', function() {
@@ -53,9 +53,13 @@ describe('XML requests', function() {
           body: '<?xml version="1.0" encoding="UTF-8"?>\n' +
           '<GetSingleItemRequest xmlns="urn:ebay:apis:eBLBaseComponents">\n' +
           '    <ItemID>123456</ItemID>\n' +
-          '</GetSingleItemRequest>'
+          '</GetSingleItemRequest>',
+          agentOptions: {
+            ciphers: 'ALL',
+            secureProtocol: 'TLSv1_method',
+          },
         });
-      })
+      });
     });
 
 
@@ -84,7 +88,7 @@ describe('XML requests', function() {
           '    <ItemID>345678</ItemID>\n' +
           '</GetMultipleItemsRequest>'
         );
-      })
+      });
     });
 
 
@@ -177,7 +181,11 @@ describe('XML requests', function() {
           '    <paginationInput>\n' +
           '        <entriesPerPage>5</entriesPerPage>\n' +
           '    </paginationInput>\n' +
-          '</findItemsByKeywordsRequest>'
+          '</findItemsByKeywordsRequest>',
+          agentOptions: {
+            ciphers: 'ALL',
+            secureProtocol: 'TLSv1_method',
+          },
         });
       });
 
@@ -215,7 +223,7 @@ describe('XML requests', function() {
           '    </ItemTransactionIDArray>\n' +
           '</GetOrderTransactionsRequest>'
         );
-      })
+      });
     });
 
   });
@@ -291,7 +299,7 @@ describe('XML requests', function() {
         expect(data).to.be.ok;
         expect(data).to.have.property('Ack', 'Failure');
         expect(data).to.have.property('Orders').that.is.instanceof(Array);
-      })
+      });
     });
 
 
@@ -335,7 +343,7 @@ describe('XML requests', function() {
         expect(data).to.be.ok;
         expect(data).to.have.property('Ack', 'Warning');
         expect(data).to.have.property('Orders').that.is.instanceof(Array);
-      })
+      });
     });
 
 
@@ -379,7 +387,7 @@ describe('XML requests', function() {
 
       it('throws an EbayClientError', function() {
         expect(err).to.be.an.instanceOf(ebay.EbayClientError);
-      })
+      });
     });
 
     describe('non-200 response code', function() {
@@ -404,7 +412,7 @@ describe('XML requests', function() {
       it('throws an EbayClientError', function() {
         expect(err).to.be.an.instanceOf(ebay.EbayClientError);
         expect(err.message).to.match(/503/);
-      })
+      });
     });
 
     describe('other client error', function() {
@@ -432,8 +440,8 @@ describe('XML requests', function() {
       it('throws an EbayClientError', function() {
         expect(err).to.be.an.instanceOf(ebay.EbayClientError);
         expect(err.message).to.match(/Boo/);
-      })
+      });
 
     });
-  })
+  });
 });


### PR DESCRIPTION
As of 3/22/2016, the eBay API has several servers that can only
negotiate TLS v1.0 sessions, and several servers that can negotiate TLS
v1.0, v1.1 and v1.2. Node/OpenSSL get confused by this, and occasionally
attempt to parse a v1.2 response using TLS v1.0 and vice versa. The
error you get back from the request looks something like this:

```
{ [Error: write EPROTO 140113357338496:error:1408F10B:SSL
routines:SSL3_GET_RECORD:wrong version number:../deps/openssl/openssl/ssl/s3_pkt.c:362:
] code: 'EPROTO',
errno: 'EPROTO',
syscall: 'write' }
```

As far as I can tell, this isn't patched yet, in Node or OpenSSL. But
setting the following options forces all connections to be negotiated
with TLS v1.0, effectively fixing the issue.

More reading:

https://github.com/aws/aws-sdk-js/issues/862
https://github.com/nodejs/node/issues/3692
https://www.ssllabs.com/ssltest/analyze.html?d=api.ebay.com

If you know anyone at eBay, please tell them it's a) unacceptable to
have servers that can only negotiate TLS v1.0, and b) unacceptable to
have a SSL certificate that was signed with SHA1, and they should
upgrade both things.